### PR TITLE
Add execute method for user operations in GatewayClientRepository

### DIFF
--- a/packages/core-js/src/api/gateway.ts
+++ b/packages/core-js/src/api/gateway.ts
@@ -1,4 +1,5 @@
 import type { RpcPayload, RpcResponse } from '@/types/api.js';
+import type { UserOp } from '@/types/core.js';
 import type {
   AuthenticatePayloadParam,
   AuthenticateResult,
@@ -36,6 +37,30 @@ class GatewayClientRepository {
     );
 
     //TODO: Check if the user is authenticated and throw an error if not
+
+    return response.data.result;
+  }
+
+  /**
+   * Executes a user operation with the Gateway service.
+   *
+   * @returns {Promise<string>} A promise that resolves to a string.
+   * @throws {Error} If the API request fails or returns an invalid response.
+   */
+  public static async execute(data: UserOp): Promise<string> {
+    const payload: RpcPayload<UserOp[]> = {
+      method: this.methods.execute,
+      jsonrpc: '2.0',
+      id: '1', //TODO: Generate UUID
+      params: [data],
+    };
+
+    const response = await gatewayClient.post<RpcResponse<string>>(
+      this.rpcRoute,
+      payload,
+    );
+
+    //TODO: Check if successful and throw an error if not
 
     return response.data.result;
   }


### PR DESCRIPTION
Introduce an `execute` method to handle user operations with the Gateway service, returning a promise that resolves to a string.