### PR TITLE
Update SDK versions to 0.6.2 and 0.5.2

### DIFF
--- a/.changeset/sixty-boxes-wash.md
+++ b/.changeset/sixty-boxes-wash.md
@@ -1,5 +1,0 @@
----
-"@okto_web3/core-js-sdk": patch
----
-
-added optional fee payer address in abstract functions

--- a/packages/core-js/CHANGELOG.md
+++ b/packages/core-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @okto_web3/core-js-sdk
 
+## 0.6.2
+
+### Patch Changes
+
+- a04c6e0: added optional fee payer address in abstract functions
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/core-js/package.json
+++ b/packages/core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/core-js-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core JS for Okto SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @okto_web3/react-native-sdk
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [a04c6e0]
+  - @okto_web3/core-js-sdk@0.6.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/react-native-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "React-Native for Okto SDK",
   "type": "module",
   "source": "./src/index.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @okto_web3/react-sdk
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [a04c6e0]
+  - @okto_web3/core-js-sdk@0.6.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/react-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "ReactJS for Okto SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Update the versions of core-js-sdk to 0.6.2 and both react-native-sdk and react-sdk to 0.5.2, including a patch that adds an optional fee payer address in abstract functions.