### PR TITLE
Update package versions and changelogs for core-js-sdk and related packages

### DIFF
--- a/.changeset/huge-ducks-guess.md
+++ b/.changeset/huge-ducks-guess.md
@@ -1,5 +1,0 @@
----
-"@okto_web3/core-js-sdk": patch
----
-
-update constants

--- a/packages/core-js/CHANGELOG.md
+++ b/packages/core-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @okto_web3/core-js-sdk
 
+## 0.6.3
+
+### Patch Changes
+
+- 049756f: update constants
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/core-js/package.json
+++ b/packages/core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/core-js-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Core JS for Okto SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @okto_web3/react-native-sdk
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [049756f]
+  - @okto_web3/core-js-sdk@0.6.3
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/react-native-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "React-Native for Okto SDK",
   "type": "module",
   "source": "./src/index.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @okto_web3/react-sdk
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [049756f]
+  - @okto_web3/core-js-sdk@0.6.3
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okto_web3/react-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "ReactJS for Okto SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Upgrade the version of core-js-sdk to 0.6.3 and update the changelogs for core-js-sdk, react-native-sdk, and react-sdk to reflect the changes.