### PR TITLE
feat: add additional allowed origins for the webview in react-sdk

### DIFF
--- a/.changeset/old-badgers-say.md
+++ b/.changeset/old-badgers-say.md
@@ -1,0 +1,5 @@
+---
+"@okto_web3/react-sdk": patch
+---
+
+add additional allowed origins for the webview

--- a/packages/react/src/webview/constants.ts
+++ b/packages/react/src/webview/constants.ts
@@ -3,6 +3,11 @@
 export const DEFAULT_ALLOWED_ORIGINS = [
   'https://onboarding.oktostage.com',
   'https://sandbox-onboarding.okto.tech',
+  'https://onboarding.okto.tech',
+  'https://sandbox-pay.okto.tech',
+  'https://pay.oktostage.com',
+  'https://pay.okto.tech',
+  'https://onboarding.okto.tech',
 ];
 
 export const DEFAULT_WEBVIEW_URL = DEFAULT_ALLOWED_ORIGINS[0]; // THIS IS THE DEFAULT URL FOR THE WEBVIEW

--- a/packages/react/src/webview/constants.ts
+++ b/packages/react/src/webview/constants.ts
@@ -7,7 +7,6 @@ export const DEFAULT_ALLOWED_ORIGINS = [
   'https://sandbox-pay.okto.tech',
   'https://pay.oktostage.com',
   'https://pay.okto.tech',
-  'https://onboarding.okto.tech',
 ];
 
 export const DEFAULT_WEBVIEW_URL = DEFAULT_ALLOWED_ORIGINS[0]; // THIS IS THE DEFAULT URL FOR THE WEBVIEW


### PR DESCRIPTION
This pull request adds additional allowed origins for the webview in the `@okto_web3/react-sdk` package to support expanded use cases. The changes include updates to the constants file and a corresponding changeset entry.

### Updates to allowed origins:

* [`packages/react/src/webview/constants.ts`](diffhunk://#diff-56e52cc26261427dc7ce746185733e8d536b92cd5c3d6175727a43084ebe8e74R6-R10): Added new URLs to the `DEFAULT_ALLOWED_ORIGINS` array, including `https://onboarding.okto.tech`, `https://sandbox-pay.okto.tech`, `https://pay.oktostage.com`, and `https://pay.okto.tech`. These changes expand the list of allowed origins for the webview.

### Changeset entry:

* [`.changeset/old-badgers-say.md`](diffhunk://#diff-a495b17e594e84b49e1def4d3b1cccf2a24d5d85e5b90e5158267b7ccc802ed9R1-R5): Added a changeset to document the patch update for the `@okto_web3/react-sdk` package, specifying the addition of new allowed origins for the webview.